### PR TITLE
QR clipping fix for the receive page

### DIFF
--- a/MiddlePanel.qml
+++ b/MiddlePanel.qml
@@ -112,7 +112,7 @@ Rectangle {
             }, State {
                name: "Receive"
                PropertyChanges { target: root; currentView: receiveView }
-               PropertyChanges { target: mainFlickable; contentHeight: minHeight }
+               PropertyChanges { target: mainFlickable; contentHeight: 1000 * scaleRatio }
             }, State {
                name: "TxKey"
                PropertyChanges { target: root; currentView: txkeyView }


### PR DESCRIPTION
Fixes QR code image clipping on the receive page due to increased content height with the new subaddr table. 